### PR TITLE
split molotov requirements into its own file

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,19 @@ The database settings are provided via environment variable, like so:
 
     DATABASE_URL=postgres://user:password@host:port/dbname ./manage.py runserver
 
+## Installation
+
+**Note**: We highly recommend to use Python 3.5+
+
+Create a `virtualenv` with your preferred tooling, then install the requirements:
+
+    python -m pip install -r requirements.txt
+    
+If you want to use Celery, you'll also need to set up a Redis instance.
+The easiest way for local development is via docker:
+
+    docker run -p 6379:6379 redis
+
 
 ## Demo Data
 

--- a/requirements.molotov.txt
+++ b/requirements.molotov.txt
@@ -1,0 +1,6 @@
+aiohttp==2.3.6
+aiomeasures==0.5.14
+async-timeout==2.0.0
+molotov==1.4
+multidict==3.3.2
+yarl==0.15.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,10 +16,3 @@ redis==2.10.6
 urllib3==1.22
 vine==1.1.4
 whitenoise==3.3.1
-
-aiohttp==2.3.6
-aiomeasures==0.5.14
-async-timeout==2.0.0
-molotov==1.4
-multidict==3.3.2
-yarl==0.15.0


### PR DESCRIPTION
This allows installing the opbeans requirements in Python 2.7