### PR TITLE
Try --no-prefix before start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,4 @@ ENV ENABLE_JSON_LOGGING=True
 
 EXPOSE 3000
 
-CMD ["honcho", "start", "--no-prefix"]
+CMD ["honcho", "--no-prefix", "start"]


### PR DESCRIPTION
Doesn't appear to be working after, and the `--help` shows it before
the command.