### PR TITLE
lighter docker image for the obpeans-python

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,10 +1,15 @@
+.ci
+.dockerignore
+.editorconfig
 .git
 .gitignore
+.gitmodules
 .vscode
 .idea
+docker-compose*.yml
+Dockerfile
 Makefile
 README.md
-Dockerfile
 client
 demo/db.sql
 opbeans/static/build
@@ -12,3 +17,4 @@ opbeans/static/build
 celerybeat-schedule
 tests
 bats
+target

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,9 @@ FROM python:3.6-slim
 COPY --from=0 /app /app
 RUN mkdir -p /app/opbeans/static/
 COPY --from=opbeans/opbeans-frontend:latest /app/build /app/opbeans/static/build
+## To get the client name/version from package.json
+COPY --from=opbeans/opbeans-frontend:latest /app/package.json /app/opbeans/static/package.json
+
 WORKDIR /app
 ENV PATH="/app/venv/bin:$PATH"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,15 @@
-FROM python:3.6
+FROM python:3.6-slim
 
 WORKDIR /app
+
+## Required as the slim version is too tiny
+RUN apt-get -qq update \
+ && apt-get -qq install -y \
+	gcc \
+    libc-dev \
+    bzip2 \
+	--no-install-recommends \
+ && rm -rf /var/lib/apt/lists/*
 
 COPY requirements*.txt /app/
 RUN pip install -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get -qq update \
 	gcc \
     libc-dev \
     bzip2 \
+    curl \
 	--no-install-recommends \
  && rm -rf /var/lib/apt/lists/*
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       apm-server:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "wget", "-q", "--server-response", "-O", "/dev/null", "http://opbeans-python:3000/"]
+      test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "--silent", "--output", "/dev/null", "http://opbeans-python:3000/"]
       interval: 10s
       retries: 10
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       apm-server:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "--silent", "--output", "/dev/null", "http://opbeans-python:3000/"]
+      test: ["CMD", "wget", "-q", "--server-response", "-O", "/dev/null", "http://opbeans-python:3000/"]
       interval: 10s
       retries: 10
 


### PR DESCRIPTION
 ## Highlights 
- From `1.1gb` docker image to `250mb`. 
- Use multistage docker images.
- Ignore unrequired files in the docker image.
- Filter what files are required from the opbeans-frontend.