### PR TITLE
Bump version 5.4.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ celery==4.2.1
 certifi
 dj-database-url==0.5.0
 django-redis==4.10.0
-elastic-apm==5.2.0
+elastic-apm==5.4.0
 elasticsearch==6.3.1
 elasticsearch-dsl==6.3.1
 gunicorn==19.9.0


### PR DESCRIPTION
Release is out.

Caused by https://github.com/elastic/apm-agent-python/releases/tag/v5.4.0