### PR TITLE
docker: add labels metadata

### DIFF
--- a/.ci/bump-version.sh
+++ b/.ci/bump-version.sh
@@ -5,6 +5,9 @@ AGENT_VERSION="${1?Missing the APM python agent version}"
 
 sed -ibck "s#elastic-apm==.*#elastic-apm==${AGENT_VERSION}#g" requirements.txt
 
+## Bump agent version in the Dockerfile
+sed -ibck "s#\(org.label-schema.version=\)\(.*\)#\1\"${AGENT_VERSION}\"#g" Dockerfile
+
 # Commit changes
-git add requirements.txt
+git add requirements.txt Dockerfile
 git commit -m "Bump version ${AGENT_VERSION}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,4 +35,13 @@ ENV ELASTIC_APM_USE_STRUCTLOG=True
 
 EXPOSE 3000
 
+LABEL \
+    org.label-schema.schema-version="1.0" \
+    org.label-schema.vendor="Elastic" \
+    org.label-schema.name="opbeans-python" \
+    org.label-schema.version="5.7.0" \
+    org.label-schema.url="https://hub.docker.com/r/opbeans/opbeans-python" \
+    org.label-schema.vcs-url="https://github.com/elastic/opbeans-python" \
+    org.label-schema.license="MIT"
+
 CMD ["honcho", "start", "--no-prefix"]


### PR DESCRIPTION
Added some labels to easily identify what's the agent version that the opbeans is consuming, in addition to some labels that are generated for some other Elastic docker images.


### Tests

```bash
IMAGE=docker.elastic.co/observability-ci/opbeans-python:63c87118dd931fdcf93bc7a6a26fb36b69546782
$ docker pull ${IMAGE}
$ docker inspect ${IMAGE} | jq -r '.[0].Config.Labels'
{
  "org.label-schema.license": "MIT",
  "org.label-schema.name": "opbeans-python",
  "org.label-schema.schema-version": "1.0",
  "org.label-schema.url": "https://hub.docker.com/r/opbeans/opbeans-python",
  "org.label-schema.vcs-url": "https://github.com/elastic/opbeans-python",
  "org.label-schema.vendor": "Elastic",
  "org.label-schema.version": "5.7.0"
}
```