### PR TITLE
fix: script to support multiline script

### DIFF
--- a/.ci/bump-version.sh
+++ b/.ci/bump-version.sh
@@ -6,7 +6,7 @@ AGENT_VERSION="${1?Missing the APM python agent version}"
 sed -ibck "s#elastic-apm==.*#elastic-apm==${AGENT_VERSION}#g" requirements.txt
 
 ## Bump agent version in the Dockerfile
-sed -ibck "s#\(org.label-schema.version=\)\(.*\)#\1\"${AGENT_VERSION}\"#g" Dockerfile
+sed -ibck "s#\(org.label-schema.version=\)\(\".*\"\)\(.*\)#\1\"${AGENT_VERSION}\"\3#g" Dockerfile
 
 # Commit changes
 git add requirements.txt Dockerfile


### PR DESCRIPTION
Otherwise:
```diff
diff --git a/Dockerfile b/Dockerfile
index 7cd2f52..368f316 100755
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ LABEL \
     org.label-schema.schema-version="1.0" \
     org.label-schema.vendor="Elastic" \
     org.label-schema.name="opbeans-python" \
-    org.label-schema.version="5.7.0" \
+    org.label-schema.version="5.8.0"
```

and now:

```diff
diff --git a/Dockerfile b/Dockerfile
index 7cd2f52..368f316 100755
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ LABEL \
     org.label-schema.schema-version="1.0" \
     org.label-schema.vendor="Elastic" \
     org.label-schema.name="opbeans-python" \
-    org.label-schema.version="5.7.0" \
+    org.label-schema.version="5.8.0" \

```