### PR TITLE
Add /labeldelay endpoint

### DIFF
--- a/opbeans/urls.py
+++ b/opbeans/urls.py
@@ -25,4 +25,5 @@ urlpatterns = [
     url(r'^api/orders/(?P<pk>[0-9]+)$', views.order, name='order-detail'),
     url(r'^images/(?P<path>.*)$', serve, kwargs={'document_root': os.path.join(settings.BASE_DIR, 'opbeans', 'static', 'build', 'images')}),
     url(r'^oopsie$', views.oopsie),
+    url(r'^labeldelay$', views.label_with_delay),
 ]

--- a/opbeans/views.py
+++ b/opbeans/views.py
@@ -290,3 +290,15 @@ def home(request):
     with elasticapm.capture_span("hard-home-work"):
         time.sleep(random.random() / 2.0)
     return render(request, "index.html")
+
+
+def label_with_delay(request):
+    labels = {}
+    for k, v in request.GET.items():
+        if k != "delay":
+            labels[k] = v
+    with elasticapm.capture_span("delayed-and-labeled", labels=labels):
+        if "delay" in request.GET:
+            time.sleep(float(request.GET["delay"]) / 1000.0)
+    return HttpResponse("OK")
+


### PR DESCRIPTION
This endpoint takes any GET parameters and makes them labels on a
span called "delayed-and-labeled". If there is a `delay` GET parameter,
then it also introduces a time.sleep, using `delay` as the number
of milliseconds to sleep.

(As requested by @cachedout )