### PR TITLE
[dependabot] enable

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+---
+version: 2
+updates:
+  # Enable version updates for python
+  - package-ecosystem: "python"
+    # Look for `requirements.txt` file in the `root` directory
+    directory: "/"
+    # Check for updates once a week
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "elastic/apm-agent-python"
+
+  # Enable version updates for Docker
+  - package-ecosystem: "docker"
+    directory: "/"
+    # Check for updates once a week
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "elastic/apm-agent-python"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,7 @@
 version: 2
 updates:
   # Enable version updates for python
-  - package-ecosystem: "python"
+  - package-ecosystem: "pip"
     # Look for `requirements.txt` file in the `root` directory
     directory: "/"
     # Check for updates once a week


### PR DESCRIPTION
### What

Enable dependabot to monitor any of the dependencies and notify the apm-agent-python team


### Why

Bump versions when required and monitor the ones related to any security issues