### PR TITLE
filter head names in jenkins builds

### DIFF
--- a/.ci/jobs/opbeans-python-mbp.yml
+++ b/.ci/jobs/opbeans-python-mbp.yml
@@ -19,7 +19,7 @@
         repo: opbeans-python
         repo-owner: elastic
         credentials-id: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken
-        head-filter-regex: '^(master|PR-.*|[5-9]\.x|v[0-9].*)$'
+        head-filter-regex: '^(main|PR-.*|[5-9]\.x|v[0-9].*)$'
         ssh-checkout:
           credentials: f6c7695a-671e-4f4f-a331-acdce44ff9ba
         build-strategies:

--- a/.ci/jobs/opbeans-python-mbp.yml
+++ b/.ci/jobs/opbeans-python-mbp.yml
@@ -10,7 +10,8 @@
     script-path: .ci/Jenkinsfile
     scm:
     - github:
-        branch-discovery: all
+        ## no-pr skips all the branches in the origin that match with a PR.
+        branch-discovery: no-pr
         discover-pr-forks-strategy: merge-current
         discover-pr-forks-trust: permission
         discover-pr-origin: merge-current

--- a/.ci/jobs/opbeans-python-mbp.yml
+++ b/.ci/jobs/opbeans-python-mbp.yml
@@ -18,6 +18,7 @@
         repo: opbeans-python
         repo-owner: elastic
         credentials-id: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken
+        head-filter-regex: '^(master|PR-.*|[5-9]\.x|v[0-9].*)$'
         ssh-checkout:
           credentials: f6c7695a-671e-4f4f-a331-acdce44ff9ba
         build-strategies:


### PR DESCRIPTION
this should avoid building PRs from dependabot twice,
as they are pushed as branches on the main repo, e.g. https://github.com/elastic/opbeans-python/pull/110

![image](https://user-images.githubusercontent.com/93675/148040439-31aa6ff0-db32-41c4-9f5f-3d308e95ef88.png)

