### PR TITLE
Bump elasticsearch to 7.17.1 and ignore 8.0 for now

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,10 @@ updates:
       interval: "weekly"
     reviewers:
       - "elastic/apm-agent-python"
+    ignore:
+      - dependency-name: "elasticsearch"  # ignore until elasticsearch-dsl is updated for 8.0
+        versions: [">=8.0.0"]
+
 
   # Enable version updates for Docker
   - package-ecosystem: "docker"

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ certifi
 dj-database-url==0.5.0
 django-redis==5.2.0
 elastic-apm==6.8.1
-elasticsearch==7.17.0
+elasticsearch==7.17.1
 elasticsearch-dsl==7.4.0
 gunicorn==20.1.0
 honcho==1.1.0


### PR DESCRIPTION
Dependabot keeps bugging us about 8.0+ versions of `elasticsearch`, but we can't update until `elasticsearch-dsl` gets some 8.0 love. 