### PR TITLE
Remove `billiard` from the requirements file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 django==4.0.4
 amqp==5.1.1
-billiard==3.6.4.0
 celery==5.2.6
 future==0.18.2
 certifi


### PR DESCRIPTION
Celery already requires this so we don't need it explicitly.