### PR TITLE
Bump elastic-apm to latest version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ LABEL \
     org.label-schema.schema-version="1.0" \
     org.label-schema.vendor="Elastic" \
     org.label-schema.name="opbeans-python" \
-    org.label-schema.version="6.15.1" \
+    org.label-schema.version="6.16.1" \
     org.label-schema.url="https://hub.docker.com/r/opbeans/opbeans-python" \
     org.label-schema.vcs-url="https://github.com/elastic/opbeans-python" \
     org.label-schema.license="MIT"

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ future==0.18.3
 certifi
 dj-database-url==2.0.0
 django-redis==5.2.0
-elastic-apm==6.16.0
+elastic-apm==6.16.1
 elasticsearch==7.17.9
 elasticsearch-dsl==7.4.1
 gunicorn==20.1.0


### PR DESCRIPTION



<Actions>
    <action id="848013299c4287fa4fb0cb44918ecd2d28fa06d47d7918537e815c2e6ce7bc91">
        <h3>Bump elastic-apm to latest version</h3>
        <details id="254db0fb64a77d55007f54b1cfb8c3dc722afb404e3dce28e3b46899bce3aacf">
            <summary>Set org.label-schema.version in Dockerfile</summary>
            <details>
                <summary>6.16.1</summary>
                <pre>&#xA;Release published on the 2023-06-06 15:30:08 +0000 UTC at the url https://github.com/elastic/apm-agent-python/releases/tag/v6.16.1&#xA;&#xA;### Bugfixes&#xD;&#xA;&#xD;&#xA;* Fix release process for docker and the lambda layer [#1845]&#xD;&#xA;&#xD;&#xA;&lt;details&gt;&#xD;&#xA;  &lt;summary&gt;Elastic APM Python agent layer ARNs&lt;/summary&gt;&#xD;&#xA;&#xD;&#xA;|Region|ARN|&#xD;&#xA;|------|---|&#xD;&#xA;|af-south-1|arn:aws:lambda:af-south-1:267093732750:layer:elastic-apm-python-ver-6-16-1:1|&#xD;&#xA;|ap-east-1|arn:aws:lambda:ap-east-1:267093732750:layer:elastic-apm-python-ver-6-16-1:1|&#xD;&#xA;|ap-northeast-1|arn:aws:lambda:ap-northeast-1:267093732750:layer:elastic-apm-python-ver-6-16-1:1|&#xD;&#xA;|ap-northeast-2|arn:aws:lambda:ap-northeast-2:267093732750:layer:elastic-apm-python-ver-6-16-1:1|&#xD;&#xA;|ap-northeast-3|arn:aws:lambda:ap-northeast-3:267093732750:layer:elastic-apm-python-ver-6-16-1:1|&#xD;&#xA;|ap-south-1|arn:aws:lambda:ap-south-1:267093732750:layer:elastic-apm-python-ver-6-16-1:1|&#xD;&#xA;|ap-southeast-1|arn:aws:lambda:ap-southeast-1:267093732750:layer:elastic-apm-python-ver-6-16-1:1|&#xD;&#xA;|ap-southeast-2|arn:aws:lambda:ap-southeast-2:267093732750:layer:elastic-apm-python-ver-6-16-1:1|&#xD;&#xA;|ap-southeast-3|arn:aws:lambda:ap-southeast-3:267093732750:layer:elastic-apm-python-ver-6-16-1:1|&#xD;&#xA;|ca-central-1|arn:aws:lambda:ca-central-1:267093732750:layer:elastic-apm-python-ver-6-16-1:1|&#xD;&#xA;|eu-central-1|arn:aws:lambda:eu-central-1:267093732750:layer:elastic-apm-python-ver-6-16-1:1|&#xD;&#xA;|eu-north-1|arn:aws:lambda:eu-north-1:267093732750:layer:elastic-apm-python-ver-6-16-1:1|&#xD;&#xA;|eu-south-1|arn:aws:lambda:eu-south-1:267093732750:layer:elastic-apm-python-ver-6-16-1:1|&#xD;&#xA;|eu-west-1|arn:aws:lambda:eu-west-1:267093732750:layer:elastic-apm-python-ver-6-16-1:1|&#xD;&#xA;|eu-west-2|arn:aws:lambda:eu-west-2:267093732750:layer:elastic-apm-python-ver-6-16-1:1|&#xD;&#xA;|eu-west-3|arn:aws:lambda:eu-west-3:267093732750:layer:elastic-apm-python-ver-6-16-1:1|&#xD;&#xA;|me-south-1|arn:aws:lambda:me-south-1:267093732750:layer:elastic-apm-python-ver-6-16-1:1|&#xD;&#xA;|sa-east-1|arn:aws:lambda:sa-east-1:267093732750:layer:elastic-apm-python-ver-6-16-1:1|&#xD;&#xA;|us-east-1|arn:aws:lambda:us-east-1:267093732750:layer:elastic-apm-python-ver-6-16-1:1|&#xD;&#xA;|us-east-2|arn:aws:lambda:us-east-2:267093732750:layer:elastic-apm-python-ver-6-16-1:1|&#xD;&#xA;|us-west-1|arn:aws:lambda:us-west-1:267093732750:layer:elastic-apm-python-ver-6-16-1:1|&#xD;&#xA;|us-west-2|arn:aws:lambda:us-west-2:267093732750:layer:elastic-apm-python-ver-6-16-1:1|&#xD;&#xA;&#xD;&#xA;&lt;/details&gt;&#xD;&#xA;&#xD;&#xA;**Full Changelog**: https://github.com/elastic/apm-agent-python/compare/v6.16.0...v6.16.1</pre>
            </details>
        </details>
        <details id="62db753b9dea229e38b38bd2cea491533bbb6164364d63d8d725017470756b66">
            <summary>Install new elastic-apm pip dependency version</summary>
            <details>
                <summary>6.16.1</summary>
                <pre>&#xA;Release published on the 2023-06-06 15:30:08 +0000 UTC at the url https://github.com/elastic/apm-agent-python/releases/tag/v6.16.1&#xA;&#xA;### Bugfixes&#xD;&#xA;&#xD;&#xA;* Fix release process for docker and the lambda layer [#1845]&#xD;&#xA;&#xD;&#xA;&lt;details&gt;&#xD;&#xA;  &lt;summary&gt;Elastic APM Python agent layer ARNs&lt;/summary&gt;&#xD;&#xA;&#xD;&#xA;|Region|ARN|&#xD;&#xA;|------|---|&#xD;&#xA;|af-south-1|arn:aws:lambda:af-south-1:267093732750:layer:elastic-apm-python-ver-6-16-1:1|&#xD;&#xA;|ap-east-1|arn:aws:lambda:ap-east-1:267093732750:layer:elastic-apm-python-ver-6-16-1:1|&#xD;&#xA;|ap-northeast-1|arn:aws:lambda:ap-northeast-1:267093732750:layer:elastic-apm-python-ver-6-16-1:1|&#xD;&#xA;|ap-northeast-2|arn:aws:lambda:ap-northeast-2:267093732750:layer:elastic-apm-python-ver-6-16-1:1|&#xD;&#xA;|ap-northeast-3|arn:aws:lambda:ap-northeast-3:267093732750:layer:elastic-apm-python-ver-6-16-1:1|&#xD;&#xA;|ap-south-1|arn:aws:lambda:ap-south-1:267093732750:layer:elastic-apm-python-ver-6-16-1:1|&#xD;&#xA;|ap-southeast-1|arn:aws:lambda:ap-southeast-1:267093732750:layer:elastic-apm-python-ver-6-16-1:1|&#xD;&#xA;|ap-southeast-2|arn:aws:lambda:ap-southeast-2:267093732750:layer:elastic-apm-python-ver-6-16-1:1|&#xD;&#xA;|ap-southeast-3|arn:aws:lambda:ap-southeast-3:267093732750:layer:elastic-apm-python-ver-6-16-1:1|&#xD;&#xA;|ca-central-1|arn:aws:lambda:ca-central-1:267093732750:layer:elastic-apm-python-ver-6-16-1:1|&#xD;&#xA;|eu-central-1|arn:aws:lambda:eu-central-1:267093732750:layer:elastic-apm-python-ver-6-16-1:1|&#xD;&#xA;|eu-north-1|arn:aws:lambda:eu-north-1:267093732750:layer:elastic-apm-python-ver-6-16-1:1|&#xD;&#xA;|eu-south-1|arn:aws:lambda:eu-south-1:267093732750:layer:elastic-apm-python-ver-6-16-1:1|&#xD;&#xA;|eu-west-1|arn:aws:lambda:eu-west-1:267093732750:layer:elastic-apm-python-ver-6-16-1:1|&#xD;&#xA;|eu-west-2|arn:aws:lambda:eu-west-2:267093732750:layer:elastic-apm-python-ver-6-16-1:1|&#xD;&#xA;|eu-west-3|arn:aws:lambda:eu-west-3:267093732750:layer:elastic-apm-python-ver-6-16-1:1|&#xD;&#xA;|me-south-1|arn:aws:lambda:me-south-1:267093732750:layer:elastic-apm-python-ver-6-16-1:1|&#xD;&#xA;|sa-east-1|arn:aws:lambda:sa-east-1:267093732750:layer:elastic-apm-python-ver-6-16-1:1|&#xD;&#xA;|us-east-1|arn:aws:lambda:us-east-1:267093732750:layer:elastic-apm-python-ver-6-16-1:1|&#xD;&#xA;|us-east-2|arn:aws:lambda:us-east-2:267093732750:layer:elastic-apm-python-ver-6-16-1:1|&#xD;&#xA;|us-west-1|arn:aws:lambda:us-west-1:267093732750:layer:elastic-apm-python-ver-6-16-1:1|&#xD;&#xA;|us-west-2|arn:aws:lambda:us-west-2:267093732750:layer:elastic-apm-python-ver-6-16-1:1|&#xD;&#xA;&#xD;&#xA;&lt;/details&gt;&#xD;&#xA;&#xD;&#xA;**Full Changelog**: https://github.com/elastic/apm-agent-python/compare/v6.16.0...v6.16.1</pre>
            </details>
        </details>
    </action>
</Actions>

---

<details><summary>Updatecli options</summary>
Most of Updatecli configuration is done via Updatecli manifest.
<ul>
<li>If you close this pullrequest, Updatecli will automatically reopen it, the next time it runs.</li>
<li>If you close this pullrequest, and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
</ul>
</details>

---

Action triggered automatically by [Updatecli](https://www.updatecli.io).

Feel free to report any issues at [github.com/updatecli/updatecli](https://github.com/updatecli/updatecli/issues/).
If you find this tool useful, do not hesitate to star our GitHub repository [github.com/updatecli/updatecli](https://github.com/updatecli/updatecli/stargazers) as a sign of appreciation.
Or tell us directly on our [chat](https://matrix.to/#/#Updatecli_community:gitter.im)

<img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="200" height="200">
