### PR TITLE
build(deps): Bump elastic-apm to 6.22.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ LABEL \
     org.label-schema.schema-version="1.0" \
     org.label-schema.vendor="Elastic" \
     org.label-schema.name="opbeans-python" \
-    org.label-schema.version="6.22.0" \
+    org.label-schema.version="6.22.2" \
     org.label-schema.url="https://hub.docker.com/r/opbeans/opbeans-python" \
     org.label-schema.vcs-url="https://github.com/elastic/opbeans-python" \
     org.label-schema.license="MIT"

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ future==1.0.0
 certifi
 dj-database-url==2.1.0
 django-redis==5.4.0
-elastic-apm==6.22.0
+elastic-apm==6.22.2
 elasticsearch==8.13.1
 elasticsearch-dsl==8.13.1
 elastic-transport==8.13.0


### PR DESCRIPTION



<Actions>
    <action id="8857d47f6d7dfc023fe0e2ce3e9f903403831a0ef0fb67c465966534857685c3">
        <h3>Bump elastic-apm to latest version</h3>
        <details id="254db0fb64a77d55007f54b1cfb8c3dc722afb404e3dce28e3b46899bce3aacf">
            <summary>Set org.label-schema.version in Dockerfile</summary>
            <p>1 file(s) updated with &#34;org.label-schema.version=\&#34;6.22.2\&#34;&#34;:&#xA;&#x9;* Dockerfile&#xA;</p>
            <details>
                <summary>6.22.2</summary>
                <pre>&#xA;Release published on the 2024-05-24 15:01:07 +0000 UTC at the url https://github.com/elastic/apm-agent-python/releases/tag/v6.22.2&#xA;&#xA;### Elastic APM Python agent layer ARNs&#xD;&#xA;&#xD;&#xA;#### Bug fixes&#xD;&#xA;&#xD;&#xA;- Fix CI release workflow #2046&#xD;&#xA;&#xD;&#xA;&lt;details&gt;&#xD;&#xA;&lt;summary&gt;Elastic APM Python agent layer ARNs&lt;/summary&gt;&#xD;&#xA;|Region|ARN|&#xD;&#xA;|------|---|&#xD;&#xA;|af-south-1|arn:aws:lambda:af-south-1:267093732750:layer:elastic-apm-python-ver-6-22-2:1|&#xD;&#xA;|ap-east-1|arn:aws:lambda:ap-east-1:267093732750:layer:elastic-apm-python-ver-6-22-2:1|&#xD;&#xA;|ap-northeast-1|arn:aws:lambda:ap-northeast-1:267093732750:layer:elastic-apm-python-ver-6-22-2:1|&#xD;&#xA;|ap-northeast-2|arn:aws:lambda:ap-northeast-2:267093732750:layer:elastic-apm-python-ver-6-22-2:1|&#xD;&#xA;|ap-northeast-3|arn:aws:lambda:ap-northeast-3:267093732750:layer:elastic-apm-python-ver-6-22-2:1|&#xD;&#xA;|ap-south-1|arn:aws:lambda:ap-south-1:267093732750:layer:elastic-apm-python-ver-6-22-2:1|&#xD;&#xA;|ap-southeast-1|arn:aws:lambda:ap-southeast-1:267093732750:layer:elastic-apm-python-ver-6-22-2:1|&#xD;&#xA;|ap-southeast-2|arn:aws:lambda:ap-southeast-2:267093732750:layer:elastic-apm-python-ver-6-22-2:1|&#xD;&#xA;|ap-southeast-3|arn:aws:lambda:ap-southeast-3:267093732750:layer:elastic-apm-python-ver-6-22-2:1|&#xD;&#xA;|ca-central-1|arn:aws:lambda:ca-central-1:267093732750:layer:elastic-apm-python-ver-6-22-2:1|&#xD;&#xA;|eu-central-1|arn:aws:lambda:eu-central-1:267093732750:layer:elastic-apm-python-ver-6-22-2:1|&#xD;&#xA;|eu-north-1|arn:aws:lambda:eu-north-1:267093732750:layer:elastic-apm-python-ver-6-22-2:1|&#xD;&#xA;|eu-south-1|arn:aws:lambda:eu-south-1:267093732750:layer:elastic-apm-python-ver-6-22-2:1|&#xD;&#xA;|eu-west-1|arn:aws:lambda:eu-west-1:267093732750:layer:elastic-apm-python-ver-6-22-2:1|&#xD;&#xA;|eu-west-2|arn:aws:lambda:eu-west-2:267093732750:layer:elastic-apm-python-ver-6-22-2:1|&#xD;&#xA;|eu-west-3|arn:aws:lambda:eu-west-3:267093732750:layer:elastic-apm-python-ver-6-22-2:1|&#xD;&#xA;|me-south-1|arn:aws:lambda:me-south-1:267093732750:layer:elastic-apm-python-ver-6-22-2:1|&#xD;&#xA;|sa-east-1|arn:aws:lambda:sa-east-1:267093732750:layer:elastic-apm-python-ver-6-22-2:1|&#xD;&#xA;|us-east-1|arn:aws:lambda:us-east-1:267093732750:layer:elastic-apm-python-ver-6-22-2:1|&#xD;&#xA;|us-east-2|arn:aws:lambda:us-east-2:267093732750:layer:elastic-apm-python-ver-6-22-2:1|&#xD;&#xA;|us-west-1|arn:aws:lambda:us-west-1:267093732750:layer:elastic-apm-python-ver-6-22-2:1|&#xD;&#xA;|us-west-2|arn:aws:lambda:us-west-2:267093732750:layer:elastic-apm-python-ver-6-22-2:1|&#xD;&#xA;&lt;/details&gt;&#xD;&#xA;&#xD;&#xA;**Full Changelog**: https://github.com/elastic/apm-agent-python/compare/v6.22.1...v6.22.2</pre>
            </details>
        </details>
        <details id="62db753b9dea229e38b38bd2cea491533bbb6164364d63d8d725017470756b66">
            <summary>Install new elastic-apm pip dependency version</summary>
            <p>1 file(s) updated with &#34;elastic-apm==6.22.2&#34;:&#xA;&#x9;* requirements.txt&#xA;</p>
            <details>
                <summary>6.22.2</summary>
                <pre>&#xA;Release published on the 2024-05-24 15:01:07 +0000 UTC at the url https://github.com/elastic/apm-agent-python/releases/tag/v6.22.2&#xA;&#xA;### Elastic APM Python agent layer ARNs&#xD;&#xA;&#xD;&#xA;#### Bug fixes&#xD;&#xA;&#xD;&#xA;- Fix CI release workflow #2046&#xD;&#xA;&#xD;&#xA;&lt;details&gt;&#xD;&#xA;&lt;summary&gt;Elastic APM Python agent layer ARNs&lt;/summary&gt;&#xD;&#xA;|Region|ARN|&#xD;&#xA;|------|---|&#xD;&#xA;|af-south-1|arn:aws:lambda:af-south-1:267093732750:layer:elastic-apm-python-ver-6-22-2:1|&#xD;&#xA;|ap-east-1|arn:aws:lambda:ap-east-1:267093732750:layer:elastic-apm-python-ver-6-22-2:1|&#xD;&#xA;|ap-northeast-1|arn:aws:lambda:ap-northeast-1:267093732750:layer:elastic-apm-python-ver-6-22-2:1|&#xD;&#xA;|ap-northeast-2|arn:aws:lambda:ap-northeast-2:267093732750:layer:elastic-apm-python-ver-6-22-2:1|&#xD;&#xA;|ap-northeast-3|arn:aws:lambda:ap-northeast-3:267093732750:layer:elastic-apm-python-ver-6-22-2:1|&#xD;&#xA;|ap-south-1|arn:aws:lambda:ap-south-1:267093732750:layer:elastic-apm-python-ver-6-22-2:1|&#xD;&#xA;|ap-southeast-1|arn:aws:lambda:ap-southeast-1:267093732750:layer:elastic-apm-python-ver-6-22-2:1|&#xD;&#xA;|ap-southeast-2|arn:aws:lambda:ap-southeast-2:267093732750:layer:elastic-apm-python-ver-6-22-2:1|&#xD;&#xA;|ap-southeast-3|arn:aws:lambda:ap-southeast-3:267093732750:layer:elastic-apm-python-ver-6-22-2:1|&#xD;&#xA;|ca-central-1|arn:aws:lambda:ca-central-1:267093732750:layer:elastic-apm-python-ver-6-22-2:1|&#xD;&#xA;|eu-central-1|arn:aws:lambda:eu-central-1:267093732750:layer:elastic-apm-python-ver-6-22-2:1|&#xD;&#xA;|eu-north-1|arn:aws:lambda:eu-north-1:267093732750:layer:elastic-apm-python-ver-6-22-2:1|&#xD;&#xA;|eu-south-1|arn:aws:lambda:eu-south-1:267093732750:layer:elastic-apm-python-ver-6-22-2:1|&#xD;&#xA;|eu-west-1|arn:aws:lambda:eu-west-1:267093732750:layer:elastic-apm-python-ver-6-22-2:1|&#xD;&#xA;|eu-west-2|arn:aws:lambda:eu-west-2:267093732750:layer:elastic-apm-python-ver-6-22-2:1|&#xD;&#xA;|eu-west-3|arn:aws:lambda:eu-west-3:267093732750:layer:elastic-apm-python-ver-6-22-2:1|&#xD;&#xA;|me-south-1|arn:aws:lambda:me-south-1:267093732750:layer:elastic-apm-python-ver-6-22-2:1|&#xD;&#xA;|sa-east-1|arn:aws:lambda:sa-east-1:267093732750:layer:elastic-apm-python-ver-6-22-2:1|&#xD;&#xA;|us-east-1|arn:aws:lambda:us-east-1:267093732750:layer:elastic-apm-python-ver-6-22-2:1|&#xD;&#xA;|us-east-2|arn:aws:lambda:us-east-2:267093732750:layer:elastic-apm-python-ver-6-22-2:1|&#xD;&#xA;|us-west-1|arn:aws:lambda:us-west-1:267093732750:layer:elastic-apm-python-ver-6-22-2:1|&#xD;&#xA;|us-west-2|arn:aws:lambda:us-west-2:267093732750:layer:elastic-apm-python-ver-6-22-2:1|&#xD;&#xA;&lt;/details&gt;&#xD;&#xA;&#xD;&#xA;**Full Changelog**: https://github.com/elastic/apm-agent-python/compare/v6.22.1...v6.22.2</pre>
            </details>
        </details>
        <a href="https://github.com/elastic/opbeans-python/actions/runs/9237882935">GitHub Action workflow link</a>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50">
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>

