### PR TITLE
requirements: bump django to 5.0.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-django==5.0.7
+django==5.0.8
 amqp==5.2.0
 celery==5.4.0
 future==1.0.0


### PR DESCRIPTION
Bump to 5.0.8 to fix dependabot warnings before adding actual testing with 5.1 in apm and bump it here