### PR TITLE
Migrate upload-artifact action to v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
 
     - name: Store test results
       if: success() || failure()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: test-results
         path: target/*.xml


### PR DESCRIPTION
The test-reporter.yml workflow – which is consuming the artifact – is currently disabled and will be fixed and re-activated in a follow-up.